### PR TITLE
Created initial version of the max-login-attempts-spring-boot-starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,115 @@
 # max-login-attempts-spring-boot-starter
+
+Spring boot starter project that can be used to put a maximum attempt on
+the number of login failures a user can make from a specific IP-address. 
+The use-case of this is to prevent hackers from brute-forcing an account.
+
+After the maximum amount of failed attempts, the user is blocked for a certain
+amount of time. During this time, an error will be presented when the user attempts
+to login, also if the credentials are correct. The waiting time and amount of tries
+are all configurable.
+
+## Registering the filter
+
+From this starter a LoginAttemptFilter bean is exposed, all you need to do to get
+this to work is add it to your spring security filter chain somewhere that you want.
+We use the [rest-secure-spring-boot-starter](https://github.com/42BV/rest-secure-spring-boot-starter),
+but you don't have to. If you do, you can add the filter like this in your client application:
+
+```java
+@Configuration
+public class CustomSecurityConfig {
+    
+    @Autowired
+    private LoginAttemptFilter loginAttemptFilter;
+
+    @Bean
+    public HttpSecurityCustomizer httpSecurityCustomizer() {
+        return http -> http.addFilterBefore(loginAttemptFilter, RestAuthenticationFilter.class);
+    }
+}
+```
+
+## Enabling/disabling the login attempt limiter
+
+When you have not provided any settings, the login limiter is enabled by default. You can
+disable this by setting the following property:
+
+```yaml
+max-login-attempts-starter:
+  enabled: false
+```
+
+## Overriding the default authentication endpoint
+
+It will operate on the POST "/authentication" endpoint only by default. You can change this
+in the following way:
+
+```yaml
+max-login-attempts-starter:
+  authentication-endpoints:
+    - path: '/authentication'
+      method: POST
+```
+
+You can also define multiple endpoints:
+
+ ```yaml
+ max-login-attempts-starter:
+   authentication-endpoints:
+     - path: '/authentication'
+       method: POST
+     - path: '/saml-authentication'
+       method: PUT
+ ```
+
+## Overriding the default maximum number of failed login attempts
+
+By default the user has 5 attempts before he is blocked. This means that on the 5th failed
+attempt the user is logged out. You can change this number the following way:
+
+```yaml
+max-login-attempts-starter:
+  max-attempts: 10
+```
+
+## Overriding the default after-blocking cooldown
+
+After the user is blocked due to too many failed login attempts, the user is by default blocked
+for 60_000 milliseconds (1 minute). You can change this value by defining the following property:
+
+```yaml
+max-login-attempts-starter:
+  cooldown-in-ms: 90000 # (1,5 minute)
+``` 
+
+## Overriding the default CRON that resets the counters
+
+Because it is probably not desirable that failed login attempts are counted "over multiple days",
+by default all failed attempt counters are reset at 00:00. You can change this by setting the following
+CRON to your desired interval:
+
+```yaml
+max-login-attempts-starter:
+  clear-all-attempts-cron: '0 0 0 25 12 *' # Christmas time at 00:00
+```
+
+## Overriding the default error handler
+
+By default, the starter will return a JSON object with a key '' and a value '' when the max login attempt
+has been reached. You can override this behaviour by exposing a bean that implements the TooManyLoginAttemptsErrorHandler
+interface:
+
+```java
+public class DefaultTooManyLoginAttemptsErrorHandler implements TooManyLoginAttemptsErrorHandler {
+       
+   @Override
+   public void handle(HttpServletResponse response) throws IOException {
+       ObjectMapper objectMapper = new ObjectMapper();
+       response.setStatus(FORBIDDEN.value());
+       response.setContentType(APPLICATION_JSON_VALUE);
+       objectMapper.writeValue(response.getWriter(), Collections.singletonMap("errorCode", "CUSTOM_ERROR_CODE"));
+       response.getWriter().flush();
+   }
+}
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>nl.42</groupId>
+    <artifactId>max-login-attempts-spring-boot-starter</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.0.4.RELEASE</version>
+    </parent>
+
+    <properties>
+        <rest-secure-starter.version>4.0.0</rest-secure-starter.version>
+        <junit-jupiter.version>5.3.2</junit-jupiter.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+
+
+        <!--- TEST DEPS -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>nl.42</groupId>
+            <artifactId>rest-secure-spring-boot-starter</artifactId>
+            <version>${rest-secure-starter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <includes>
+                        <include>*Test.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/AuthenticationEndpoint.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/AuthenticationEndpoint.java
@@ -1,0 +1,32 @@
+package nl._42.max_login_attempts_spring_boot_starter;
+
+import org.springframework.http.HttpMethod;
+
+public class AuthenticationEndpoint {
+
+    private String path;
+    private HttpMethod method;
+
+    public static AuthenticationEndpoint create(String path, HttpMethod method) {
+        AuthenticationEndpoint authenticationEndpoint = new AuthenticationEndpoint();
+        authenticationEndpoint.path = path;
+        authenticationEndpoint.method = method;
+        return authenticationEndpoint;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public HttpMethod getMethod() {
+        return method;
+    }
+
+    public void setMethod(HttpMethod method) {
+        this.method = method;
+    }
+}

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/LoginAttemptConfiguration.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/LoginAttemptConfiguration.java
@@ -1,0 +1,54 @@
+package nl._42.max_login_attempts_spring_boot_starter;
+
+import static java.util.Collections.singletonList;
+import static org.springframework.http.HttpMethod.POST;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "max-login-attempts-starter")
+public class LoginAttemptConfiguration {
+
+    private boolean enabled = true;
+    private int maxAttempts = 5;
+    private int cooldown = 60000;
+    private List<AuthenticationEndpoint> authenticationEndpoints = singletonList(
+        AuthenticationEndpoint.create("/authentication", POST)
+    );
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public int getMaxAttempts() {
+        return maxAttempts;
+    }
+
+    public void setMaxAttempts(int maxAttempts) {
+        this.maxAttempts = maxAttempts;
+    }
+
+    public int getCooldown() {
+        return cooldown;
+    }
+
+    public void setCooldown(int cooldown) {
+        this.cooldown = cooldown;
+    }
+
+    public List<AuthenticationEndpoint> getAuthenticationEndpoints() {
+        return authenticationEndpoints;
+    }
+
+    public void setAuthenticationEndpoints(List<AuthenticationEndpoint> authenticationEndpoints) {
+        this.authenticationEndpoints = Collections.unmodifiableList(authenticationEndpoints);
+    }
+}

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/LoginAttemptsAutoConfig.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/LoginAttemptsAutoConfig.java
@@ -1,0 +1,12 @@
+package nl._42.max_login_attempts_spring_boot_starter;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan(basePackages = "nl._42.max_login_attempts_spring_boot_starter")
+@EnableConfigurationProperties
+public class LoginAttemptsAutoConfig {
+
+}

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/error/TooManyLoginAttemptsErrorHandler.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/error/TooManyLoginAttemptsErrorHandler.java
@@ -1,0 +1,26 @@
+package nl._42.max_login_attempts_spring_boot_starter.error;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * You can create a bean implementing this interface
+ * if you wish to override the default result that is
+ * sent back to the user when the login attempt limit
+ * has been reached.
+ */
+@Component
+public interface TooManyLoginAttemptsErrorHandler {
+
+    /**
+     * Handling method for when a user has attempted to login too many times.
+     * Can be used to return a result on the HttpServletResponse.
+     *
+     * @param response HttpServletResponse
+     * @throws IOException exception
+     */
+    void handle(HttpServletResponse response) throws IOException;
+}

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/filter/ConsumingHttpServletRequestWrapper.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/filter/ConsumingHttpServletRequestWrapper.java
@@ -1,0 +1,41 @@
+package nl._42.max_login_attempts_spring_boot_starter.filter;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+import org.apache.commons.io.IOUtils;
+
+/**
+ * Used to allow re-reads of login form in subsequent filters.
+ * Source: https://stackoverflow.com/questions/4449096/how-to-read-request-getinputstream-multiple-times
+ */
+class ConsumingHttpServletRequestWrapper extends HttpServletRequestWrapper {
+
+    private byte[] body;
+
+    ConsumingHttpServletRequestWrapper(HttpServletRequest request) {
+        super(request);
+
+        try {
+            body = IOUtils.toByteArray(request.getInputStream());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public ServletInputStream getInputStream() {
+        return new DelegatingServletInputStream(new ByteArrayInputStream(body));
+    }
+
+    @Override
+    public BufferedReader getReader() {
+        return new BufferedReader(new InputStreamReader(getInputStream()));
+    }
+}

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/filter/DefaultTooManyLoginAttemptsErrorHandler.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/filter/DefaultTooManyLoginAttemptsErrorHandler.java
@@ -1,0 +1,30 @@
+package nl._42.max_login_attempts_spring_boot_starter.filter;
+
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import javax.servlet.http.HttpServletResponse;
+
+import nl._42.max_login_attempts_spring_boot_starter.error.TooManyLoginAttemptsErrorHandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Default implementation of TooManyLoginAttemptsErrorHandler.
+ * It outputs a JSON object with a field "errorCode" and a value
+ * "TOO_MANY_LOGIN_ATTEMPTS". The status is 403 Forbidden.
+ */
+class DefaultTooManyLoginAttemptsErrorHandler implements TooManyLoginAttemptsErrorHandler {
+
+    @Override
+    public void handle(HttpServletResponse response) throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.setStatus(FORBIDDEN.value());
+        response.setContentType(APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(response.getWriter(), Collections.singletonMap("errorCode", "TOO_MANY_LOGIN_ATTEMPTS"));
+        response.getWriter().flush();
+    }
+}

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/filter/DelegatingServletInputStream.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/filter/DelegatingServletInputStream.java
@@ -1,0 +1,62 @@
+package nl._42.max_login_attempts_spring_boot_starter.filter;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.servlet.ReadListener;
+import javax.servlet.ServletInputStream;
+
+/**
+ * Used to create the {@link ConsumingHttpServletRequestWrapper}.
+ * Source: https://stackoverflow.com/questions/4449096/how-to-read-request-getinputstream-multiple-times
+ */
+class DelegatingServletInputStream extends ServletInputStream {
+
+    private final InputStream sourceStream;
+
+    private boolean finished = false;
+
+    /**
+     * Create a DelegatingServletInputStream for the given source stream.
+     *
+     * @param sourceStream the source stream (never {@code null})
+     */
+    DelegatingServletInputStream(InputStream sourceStream) {
+        this.sourceStream = sourceStream;
+    }
+
+    @Override
+    public int read() throws IOException {
+        int data = this.sourceStream.read();
+        if (data == -1) {
+            this.finished = true;
+        }
+        return data;
+    }
+
+    @Override
+    public int available() throws IOException {
+        return this.sourceStream.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+        this.sourceStream.close();
+    }
+
+    @Override
+    public boolean isFinished() {
+        return this.finished;
+    }
+
+    @Override
+    public boolean isReady() {
+        return true;
+    }
+
+    @Override
+    public void setReadListener(ReadListener readListener) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/filter/LoginAttemptFilter.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/filter/LoginAttemptFilter.java
@@ -1,0 +1,106 @@
+package nl._42.max_login_attempts_spring_boot_starter.filter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import nl._42.max_login_attempts_spring_boot_starter.LoginAttemptConfiguration;
+import nl._42.max_login_attempts_spring_boot_starter.error.TooManyLoginAttemptsErrorHandler;
+import nl._42.max_login_attempts_spring_boot_starter.listener.UsernameRemoteAddressBlockedException;
+import nl._42.max_login_attempts_spring_boot_starter.service.LoginAttemptService;
+
+import org.apache.commons.io.IOUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Filter which checks if the login request is executed while the user is already blocked
+ * due to an excessive amount of login attempts. If so, a forbidden status with a specific
+ * error code is returned.
+ */
+@Component
+public class LoginAttemptFilter extends OncePerRequestFilter {
+
+    private final LoginAttemptService loginAttemptService;
+    private final TooManyLoginAttemptsErrorHandler tooManyLoginAttemptsErrorHandler;
+
+    private final LoginAttemptConfiguration loginAttemptConfiguration;
+
+    private final List<AntPathRequestMatcher> authenticationRequestMatchers;
+
+    @Autowired
+    public LoginAttemptFilter(
+        LoginAttemptService loginAttemptService,
+        @Autowired(required = false) Optional<TooManyLoginAttemptsErrorHandler> tooManyLoginAttemptsErrorHandler,
+        LoginAttemptConfiguration loginAttemptConfiguration
+    ) {
+        this.loginAttemptService = loginAttemptService;
+        this.tooManyLoginAttemptsErrorHandler = tooManyLoginAttemptsErrorHandler.orElse(new DefaultTooManyLoginAttemptsErrorHandler());
+        this.loginAttemptConfiguration = loginAttemptConfiguration;
+
+        this.authenticationRequestMatchers = loginAttemptConfiguration.getAuthenticationEndpoints()
+                .stream()
+                .map(loginEndpoint -> new AntPathRequestMatcher(loginEndpoint.getPath(), loginEndpoint.getMethod().name()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        /*
+          The request passed to the next filter is,
+          by default, the normal incoming HttpServletRequest.
+          If we attempt to check the username here we wrap it in
+          a {@link ConsumingHttpServletRequestWrapper} so it can
+          be reread in the {@link nl._42.restsecure.autoconfigure.RestAuthenticationFilter}.
+         */
+        HttpServletRequest passedRequest = request;
+
+        if (loginAttemptConfiguration.isEnabled() && authenticationRequestMatchers.stream().anyMatch(matcher -> matcher.matches(request))) {
+
+            /*
+             * If this is the login request we wrap the HttpServletRequest
+             * before reading it, because once the {@link HttpServletRequest}
+             * is read it is exhausted.
+             */
+            passedRequest = new ConsumingHttpServletRequestWrapper(request);
+
+            if (loginAttemptService.isBlocked(readUsername(passedRequest), request.getRemoteAddr())) {
+                handleUsernameIpAddressBlocked(response);
+                return;
+            }
+        }
+
+        /*
+         * If this request is the one that causes the block we need
+         * to handle the error now, and not in the next request.
+         */
+        try {
+            filterChain.doFilter(passedRequest, response);
+        } catch (UsernameRemoteAddressBlockedException e) {
+            handleUsernameIpAddressBlocked(response);
+        }
+    }
+
+    private void handleUsernameIpAddressBlocked(HttpServletResponse response) throws IOException {
+        tooManyLoginAttemptsErrorHandler.handle(response);
+        SecurityContextHolder.getContext().setAuthentication(null);
+    }
+
+    private String readUsername(HttpServletRequest request) throws IOException {
+        String loginFormJson = IOUtils.toString(request.getReader());
+        ObjectNode node = new ObjectMapper().readValue(loginFormJson, ObjectNode.class);
+        return node.get("username").asText();
+    }
+}

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/listener/AuthenticationFailureListener.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/listener/AuthenticationFailureListener.java
@@ -1,0 +1,46 @@
+package nl._42.max_login_attempts_spring_boot_starter.listener;
+
+import javax.servlet.http.HttpServletRequest;
+
+import nl._42.max_login_attempts_spring_boot_starter.service.LoginAttemptService;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationListener;
+import org.springframework.security.authentication.event.AuthenticationFailureBadCredentialsEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * Listener which retrieves the remote address of the user when a login attempt fails and notifies
+ * the LoginAttemptService of this fact.
+ */
+@Component
+public class AuthenticationFailureListener implements ApplicationListener<AuthenticationFailureBadCredentialsEvent> {
+
+    private final LoginAttemptService loginAttemptService;
+
+    @Autowired
+    public AuthenticationFailureListener(LoginAttemptService loginAttemptService) {
+        this.loginAttemptService = loginAttemptService;
+    }
+
+    @Override
+    public void onApplicationEvent(AuthenticationFailureBadCredentialsEvent event) {
+        RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+        if (requestAttributes instanceof ServletRequestAttributes) {
+            String username = String.valueOf(event.getAuthentication().getPrincipal());
+            HttpServletRequest request = ((ServletRequestAttributes)requestAttributes).getRequest();
+
+            boolean nowBlocked = loginAttemptService.loginFailed(username, request.getRemoteAddr());
+            if (nowBlocked) {
+                /* If the user is now blocked we throw a UsernameRemoteAddressBlockedException, which is caught in
+                 * the LoginAttemptFilter. Without doing this we will only get an error the next time the user
+                 * attempts to log in, but the user is already blocked now.
+                 */
+                throw new UsernameRemoteAddressBlockedException(username, request.getRemoteAddr());
+            }
+        }
+    }
+}

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/listener/AuthenticationSuccessListener.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/listener/AuthenticationSuccessListener.java
@@ -1,0 +1,34 @@
+package nl._42.max_login_attempts_spring_boot_starter.listener;
+
+import javax.servlet.http.HttpServletRequest;
+
+import nl._42.max_login_attempts_spring_boot_starter.service.LoginAttemptService;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationListener;
+import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Component
+public class AuthenticationSuccessListener implements ApplicationListener<AuthenticationSuccessEvent> {
+
+    private final LoginAttemptService loginAttemptService;
+
+    @Autowired
+    public AuthenticationSuccessListener(LoginAttemptService loginAttemptService) {
+        this.loginAttemptService = loginAttemptService;
+    }
+
+    @Override
+    public void onApplicationEvent(AuthenticationSuccessEvent event) {
+        RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+        if (requestAttributes instanceof ServletRequestAttributes) {
+            String username = String.valueOf(event.getAuthentication().getPrincipal());
+            HttpServletRequest request = ((ServletRequestAttributes)requestAttributes).getRequest();
+            loginAttemptService.loginSucceeded(username, request.getRemoteAddr());
+        }
+    }
+}

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/listener/UsernameRemoteAddressBlockedException.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/listener/UsernameRemoteAddressBlockedException.java
@@ -1,0 +1,8 @@
+package nl._42.max_login_attempts_spring_boot_starter.listener;
+
+public class UsernameRemoteAddressBlockedException extends RuntimeException {
+
+    UsernameRemoteAddressBlockedException(String username, String remoteAddr) {
+        super("Username " + username + " is now blocked on remote address " + remoteAddr);
+    }
+}

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/service/LoginAttemptService.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/service/LoginAttemptService.java
@@ -1,0 +1,15 @@
+package nl._42.max_login_attempts_spring_boot_starter.service;
+
+/**
+ * Service which keeps track of login attempts performed from a given remote address.
+ */
+public interface LoginAttemptService {
+
+    boolean loginFailed(String username, String remoteAddress);
+
+    void loginSucceeded(String username, String remoteAddress);
+
+    boolean isBlocked(String username, String remoteAddress);
+
+    void reset();
+}

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/service/LoginAttemptServiceImplementation.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/service/LoginAttemptServiceImplementation.java
@@ -1,0 +1,134 @@
+package nl._42.max_login_attempts_spring_boot_starter.service;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.concurrent.ConcurrentHashMap;
+
+import nl._42.max_login_attempts_spring_boot_starter.LoginAttemptConfiguration;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@ConditionalOnProperty(value = "max-login-attempts-starter.enabled", matchIfMissing = true)
+public class LoginAttemptServiceImplementation implements LoginAttemptService {
+
+    public static final String DEFAULT_CLEAR_ALL_ATTEMPTS_CRON = "'0 0 0 * * *'";
+
+    private final LoginAttemptConfiguration loginAttemptConfiguration;
+    private final Clock clock;
+
+    private final ConcurrentHashMap<UsernameIPAddress, Integer> attemptsCache;
+    private final ConcurrentHashMap<UsernameIPAddress, LocalDateTime> blockedUsernameIPAddresses;
+
+    @Autowired
+    public LoginAttemptServiceImplementation(LoginAttemptConfiguration loginAttemptConfiguration, Clock clock) {
+        this.loginAttemptConfiguration = loginAttemptConfiguration;
+        this.clock = clock;
+
+        this.attemptsCache = new ConcurrentHashMap<>();
+        this.blockedUsernameIPAddresses = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Marks a failed login attempt for the remote address.
+     * A counter is kept to keep track of the amount of failed logins
+     * and if this surpasses the maximum amount of times configured in
+     * the properties file, the user is locked out until  the cooldown
+     * time surpasses.
+     *
+     * The mechanism uses a ConcurrentHashMap to keep track of the amount
+     * of tries, and a PriorityBlockingQueue to easily traverse through
+     * the entries that are marked for unblocking in the correct order.
+     *
+     * @param remoteAddress remote internet address
+     * @return boolean - whether or not the user is (now) blocked.
+     */
+    @Override
+    public synchronized boolean loginFailed(String username, String remoteAddress) {
+        // If the remoteAddress is already blocked we don't need to do anything and return.
+        if (isBlocked(username, remoteAddress)) {
+            return true;
+        }
+
+        UsernameIPAddress usernameIPAddress = new UsernameIPAddress(username, remoteAddress);
+
+        int attempts = attemptsCache.getOrDefault(usernameIPAddress, 0);
+        attemptsCache.put(usernameIPAddress, attempts + 1);
+
+        /*
+         * If the remoteAddress is now blocked we mark it for removal
+         * but we clear the attempts so the counter starts to re-run
+         * when the unblock deadline has passed.
+         */
+        if (hasReachedLoginAttemptLimit(username, remoteAddress)) {
+            clearAttempts(usernameIPAddress);
+            blockedUsernameIPAddresses.put(usernameIPAddress, LocalDateTime.now(clock).plusSeconds(loginAttemptConfiguration.getCooldown() / 1000));
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean hasReachedLoginAttemptLimit(String username, String remoteAddress) {
+        UsernameIPAddress usernameIPAddress = new UsernameIPAddress(username, remoteAddress);
+        int attempts = attemptsCache.getOrDefault(usernameIPAddress, 0);
+        return attempts >= loginAttemptConfiguration.getMaxAttempts();
+    }
+
+    /**
+     * Marks a login attempt as successful, clearing the previous
+     * amount of failed attempts (if any).
+     * @param remoteAddress remote internet address
+     */
+    @Override
+    public void loginSucceeded(String username, String remoteAddress) {
+        UsernameIPAddress usernameIPAddress = new UsernameIPAddress(username, remoteAddress);
+        clearAttempts(usernameIPAddress);
+    }
+
+    private void clearAttempts(UsernameIPAddress usernameIPAddress) {
+        attemptsCache.remove(usernameIPAddress);
+    }
+
+    /**
+     * Returns true if the remote address is currently blocked.
+     * @param remoteAddress remote internet address
+     * @return whether or not the remote address is blocked
+     */
+    @Override
+    public synchronized boolean isBlocked(String username, String remoteAddress) {
+        UsernameIPAddress usernameIPAddress = new UsernameIPAddress(username, remoteAddress);
+
+        /*
+         * If the username/ip-address combination is not currently in the
+         * blockedUsernameIPAddresses map we are sure it is not blocked.
+         */
+        if (!blockedUsernameIPAddresses.containsKey(usernameIPAddress)) {
+            return false;
+        }
+
+        // Otherwise we retrieve the deadline and check if it has passed.
+        // If it has passed we do a little cleanup and remove the record.
+        LocalDateTime deadline = blockedUsernameIPAddresses.get(usernameIPAddress);
+        if (LocalDateTime.now(clock).isBefore(deadline)) {
+            return true;
+        } else {
+            blockedUsernameIPAddresses.remove(usernameIPAddress);
+            return false;
+        }
+    }
+
+    /**
+     * Completely reset all attempts.
+     * Can be executed manually and also be scheduled to reset automatically.
+     */
+    @Override
+    @Scheduled(cron = "${max-login-attempts-starter.clear-all-attempts-cron:#{" + DEFAULT_CLEAR_ALL_ATTEMPTS_CRON + "}}")
+    public synchronized void reset() {
+        attemptsCache.clear();
+        blockedUsernameIPAddresses.clear();
+    }
+}

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/service/LoginAttemptServiceStub.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/service/LoginAttemptServiceStub.java
@@ -1,0 +1,29 @@
+package nl._42.max_login_attempts_spring_boot_starter.service;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+@Service
+@ConditionalOnProperty(value = "max-login-attempts-starter.enabled", havingValue = "false")
+public class LoginAttemptServiceStub implements LoginAttemptService {
+
+    @Override
+    public boolean isBlocked(String username, String remoteAddress) {
+        return false;
+    }
+
+    @Override
+    public boolean loginFailed(String username, String remoteAddress) {
+        return false;
+    }
+
+    @Override
+    public void reset() {
+        // do nothing
+    }
+
+    @Override
+    public void loginSucceeded(String username, String remoteAddress) {
+        // do nothing
+    }
+}

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/service/UsernameIPAddress.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/service/UsernameIPAddress.java
@@ -1,0 +1,60 @@
+package nl._42.max_login_attempts_spring_boot_starter.service;
+
+import org.apache.commons.lang3.builder.CompareToBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+/**
+ * Tuple class that holds a combination of username and IP-address,
+ * which is the combined key to determine if a user account is
+ * temporarily blocked.
+ */
+class UsernameIPAddress implements Comparable<UsernameIPAddress> {
+
+    private final String username;
+    private final String ipAddress;
+
+    UsernameIPAddress(String username, String ipAddress) {
+        this.username = username;
+        this.ipAddress = ipAddress;
+    }
+
+    String getUsername() {
+        return username;
+    }
+
+    String getIpAddress() {
+        return ipAddress;
+    }
+
+    @Override
+    public int compareTo(UsernameIPAddress o) {
+        return new CompareToBuilder()
+                .append(username, o.username)
+                .append(ipAddress, o.ipAddress)
+                .build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        UsernameIPAddress other = (UsernameIPAddress) o;
+
+        return new EqualsBuilder()
+                .append(username, other.username)
+                .append(ipAddress, other.ipAddress)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder()
+                .append(username)
+                .append(ipAddress)
+                .build();
+    }
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=nl._42.max_login_attempts_spring_boot_starter.LoginAttemptsAutoConfig

--- a/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/AbstractSpringTest.java
+++ b/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/AbstractSpringTest.java
@@ -1,0 +1,26 @@
+package nl._42.max_login_attempts_spring_boot_starter;
+
+import nl._42.max_login_attempts_spring_boot_starter.service.LoginAttemptService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = LoginAttemptService.class)
+@Import({ TestConfiguration.class })
+@ActiveProfiles({ "unit-test", "disable-scheduling" })
+public abstract class AbstractSpringTest {
+
+    @Autowired
+    private LoginAttemptService loginAttemptService;
+
+    @BeforeEach
+    void clearLoginAttempts() {
+        loginAttemptService.reset();
+    }
+}

--- a/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/AbstractWebIntegrationTest.java
+++ b/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/AbstractWebIntegrationTest.java
@@ -1,0 +1,37 @@
+package nl._42.max_login_attempts_spring_boot_starter;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.anonymous;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public abstract class AbstractWebIntegrationTest extends AbstractSpringTest {
+
+    @Autowired
+    protected WebApplicationContext applicationContext;
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    protected MockMvc webClient;
+
+    @BeforeEach
+    public void setUpMockMvc() {
+        webClient = webAppContextSetup(applicationContext)
+            .apply(springSecurity())
+            .defaultRequest(get("/")
+                .contentType(APPLICATION_JSON)
+                .with(anonymous()))
+            .alwaysDo(log())
+            .build();
+    }
+
+}

--- a/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/AdjustableClock.java
+++ b/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/AdjustableClock.java
@@ -1,0 +1,40 @@
+package nl._42.max_login_attempts_spring_boot_starter;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public class AdjustableClock extends Clock {
+
+    private Clock clock;
+
+    public AdjustableClock() {
+        reset();
+    }
+
+    public void reset() {
+        this.clock = Clock.systemDefaultZone();
+    }
+
+    public void setTime(LocalDateTime time) {
+        Instant instant = ZonedDateTime.of(time, ZoneId.systemDefault()).toInstant();
+        this.clock = Clock.fixed(instant, ZoneId.systemDefault());
+    }
+
+    @Override
+    public ZoneId getZone() {
+        return clock.getZone();
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+        return clock.withZone(zone);
+    }
+
+    @Override
+    public Instant instant() {
+        return clock.instant();
+    }
+}

--- a/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/MockUserDetailsService.java
+++ b/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/MockUserDetailsService.java
@@ -1,0 +1,37 @@
+package nl._42.max_login_attempts_spring_boot_starter;
+
+import java.util.Collections;
+import java.util.Set;
+
+import nl._42.restsecure.autoconfigure.authentication.AbstractUserDetailsService;
+import nl._42.restsecure.autoconfigure.authentication.RegisteredUser;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public class MockUserDetailsService extends AbstractUserDetailsService {
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Override
+    protected RegisteredUser findUserByUsername(String user) {
+        return new RegisteredUser() {
+
+            @Override
+            public String getUsername() {
+                return user;
+            }
+
+            @Override
+            public String getPassword() {
+                return passwordEncoder.encode("welkom");
+            }
+
+            @Override
+            public Set<String> getAuthorities() {
+                return Collections.singleton("admin");
+            }
+        };
+    }
+}

--- a/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/TestConfiguration.java
+++ b/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/TestConfiguration.java
@@ -1,0 +1,67 @@
+package nl._42.max_login_attempts_spring_boot_starter;
+
+import java.time.Clock;
+
+import nl._42.max_login_attempts_spring_boot_starter.filter.LoginAttemptFilter;
+import nl._42.restsecure.autoconfigure.HttpSecurityCustomizer;
+import nl._42.restsecure.autoconfigure.RestAuthenticationFilter;
+import nl._42.restsecure.autoconfigure.WebSecurityAutoConfig;
+import nl._42.restsecure.autoconfigure.errorhandling.GenericErrorHandler;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Configuration
+@ComponentScan(value = "nl._42.max_login_attempts_spring_boot_starter")
+@Import({ WebSecurityAutoConfig.class })
+@EnableWebSecurity
+@EnableWebMvc
+@Order(200)
+public class TestConfiguration extends WebSecurityConfigurerAdapter {
+
+    @Autowired
+    @Lazy
+    private LoginAttemptFilter loginAttemptFilter;
+
+    @Bean
+    public Clock clock() {
+        return new AdjustableClock();
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+
+    @Bean
+    public MockUserDetailsService mockUserDetailsService() {
+        return new MockUserDetailsService();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public HttpSecurityCustomizer httpSecurityCustomizer() {
+        return http -> http.csrf().disable().addFilter(new RestAuthenticationFilter(genericErrorHandler(), authenticationManager())).addFilterBefore(loginAttemptFilter, RestAuthenticationFilter.class);
+    }
+
+    @Bean
+    public GenericErrorHandler genericErrorHandler() {
+        return new GenericErrorHandler();
+    }
+}

--- a/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/integration/AuthenticationMaxLoginAttemptsTest.java
+++ b/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/integration/AuthenticationMaxLoginAttemptsTest.java
@@ -1,0 +1,96 @@
+package nl._42.max_login_attempts_spring_boot_starter.integration;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import java.time.LocalDateTime;
+
+import nl._42.max_login_attempts_spring_boot_starter.AbstractWebIntegrationTest;
+import nl._42.max_login_attempts_spring_boot_starter.AdjustableClock;
+import nl._42.max_login_attempts_spring_boot_starter.service.LoginAttemptService;
+import nl._42.restsecure.autoconfigure.RestAuthenticationFilter;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+class AuthenticationMaxLoginAttemptsTest extends AbstractWebIntegrationTest {
+
+    @Autowired
+    private AdjustableClock adjustableClock;
+
+    @Autowired
+    private LoginAttemptService loginAttemptService;
+
+    @Test
+    void loginAndLogoutLog() throws Exception {
+        // The current time is January 1st, 2020, 00:00:00
+        adjustableClock.setTime(LocalDateTime.of(2020, 1, 1, 0, 0, 0));
+
+        RestAuthenticationFilter.LoginForm incorrectLoginForm = new RestAuthenticationFilter.LoginForm();
+        incorrectLoginForm.username = "admin";
+        incorrectLoginForm.password = "niet-welkom-1337";
+
+        RestAuthenticationFilter.LoginForm correctLoginForm = new RestAuthenticationFilter.LoginForm();
+        correctLoginForm.username = "admin";
+        correctLoginForm.password = "welkom";
+
+        RestAuthenticationFilter.LoginForm pietLoginForm = new RestAuthenticationFilter.LoginForm();
+        pietLoginForm.username = "other-user";
+        pietLoginForm.password = "niet-welkom";
+
+
+        // The first two attempts are 'free'.
+        webClient
+            .perform(MockMvcRequestBuilders.post("/authentication")
+            .content(objectMapper.writeValueAsString(incorrectLoginForm)))
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.status().isUnauthorized());
+
+        webClient
+            .perform(MockMvcRequestBuilders.post("/authentication")
+            .content(objectMapper.writeValueAsString(incorrectLoginForm)))
+            .andExpect(MockMvcResultMatchers.status().isUnauthorized());
+
+        // At the third incorrect attempt we tried too many times and we are blocked, for the 'Jan' username,
+        // but not for the 'Piet' account.
+        webClient
+            .perform(MockMvcRequestBuilders.post("/authentication")
+            .content(objectMapper.writeValueAsString(incorrectLoginForm)))
+            .andExpect(MockMvcResultMatchers.status().isForbidden())
+            .andExpect(jsonPath("errorCode").value("TOO_MANY_LOGIN_ATTEMPTS"));
+
+        webClient
+            .perform(MockMvcRequestBuilders.post("/authentication")
+            .content(objectMapper.writeValueAsString(pietLoginForm)))
+            .andExpect(MockMvcResultMatchers.status().isUnauthorized());
+
+        // We can also still attempt a login with 'Jan' from another IP.
+        webClient
+            .perform(MockMvcRequestBuilders.post("/authentication")
+            .content(objectMapper.writeValueAsString(incorrectLoginForm))
+            .with(mockHttpServletRequest -> {
+                mockHttpServletRequest.setRemoteAddr("127.0.0.2");
+                return mockHttpServletRequest;
+            }))
+            .andExpect(MockMvcResultMatchers.status().isUnauthorized());
+
+        // The cooldown time is 1 minute, so we set it just before that minute and try again with the correct credentials, but we are already blocked.
+        adjustableClock.setTime(LocalDateTime.of(2020, 1, 1, 0, 0, 59));
+
+        webClient
+            .perform(MockMvcRequestBuilders.post("/authentication")
+            .content(objectMapper.writeValueAsString(correctLoginForm)))
+            .andExpect(MockMvcResultMatchers.status().isForbidden())
+            .andExpect(jsonPath("errorCode").value("TOO_MANY_LOGIN_ATTEMPTS"));
+
+        // Then we fast-forward time to the point the cache is void and we try again
+        adjustableClock.setTime(LocalDateTime.of(2020, 1, 1, 0, 1, 1));
+
+        webClient
+            .perform(MockMvcRequestBuilders.post("/authentication")
+            .content(objectMapper.writeValueAsString(correctLoginForm)))
+            .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+}

--- a/src/test/resources/application-unit-test.yml
+++ b/src/test/resources/application-unit-test.yml
@@ -1,0 +1,2 @@
+max-login-attempts-starter:
+  max-attempts: 3


### PR DESCRIPTION
This is the initial version of the starter,
it can be used to put a maximum attempt on
the number of login failures a user can make
from a specific IP-address. The use-case of
this is to prevent hackers from brute-forcing
an account.

After the maximum amount of failed
attempts, the user is blocked for a certain
amount of time. During this time, an error
will be presented when the user attempts
to login, also if the credentials are
correct. The waiting time and amount of tries
are all configurable.