### PR TITLE
Added the ability to clear the attempts after specified duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ max-login-attempts-starter:
   clear-all-attempts-cron: '0 0 0 25 12 *' # Christmas time at 00:00
 ```
 
+## Enabling the reset of attempts by username after specified ms 
+
+By default the attempt won't reset until the clear-all-attempts-cron has been run. You can add the following
+property to reset the attempts by a username after a specified time. 
+
+```yaml
+max-login-attempts-starter:
+  clear-attempts-seconds: 1800 # reset attempts after the last attempt if 30 minutes have passed
+```
+
 ## Enabling debug logging
 
 If you want more specific information on failed login attempts, enable debug logging as follows:

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <rest-secure-starter.version>7.4.2</rest-secure-starter.version>
+        <rest-secure-starter.version>8.0.1</rest-secure-starter.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <commons-io.version>2.8.0</commons-io.version>

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/LoginAttemptConfiguration.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/LoginAttemptConfiguration.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpMethod.POST;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -16,6 +17,7 @@ public class LoginAttemptConfiguration {
     private boolean enabled = true;
     private int maxAttempts = 5;
     private int cooldown = 60000;
+    private Integer clearAttemptsSeconds;
     private List<AuthenticationEndpoint> authenticationEndpoints = singletonList(
             AuthenticationEndpoint.create("/authentication", POST)
     );
@@ -42,6 +44,14 @@ public class LoginAttemptConfiguration {
 
     public void setCooldown(int cooldown) {
         this.cooldown = cooldown;
+    }
+
+    public Integer getClearAttemptsSeconds() {
+        return clearAttemptsSeconds;
+    }
+
+    public void setClearAttemptsSeconds(Integer clearAttemptsSeconds) {
+        this.clearAttemptsSeconds = clearAttemptsSeconds;
     }
 
     public List<AuthenticationEndpoint> getAuthenticationEndpoints() {

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/service/Attempts.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/service/Attempts.java
@@ -1,0 +1,30 @@
+package nl._42.max_login_attempts_spring_boot_starter.service;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+public class Attempts {
+    private final Clock clock;
+    private Integer totalAttempts;
+    private LocalDateTime lastAttemptTime;
+
+    public Attempts(Clock clock) {
+        this.totalAttempts = 0;
+        this.lastAttemptTime = LocalDateTime.now(clock);
+        this.clock = clock;
+    }
+
+    public Integer getTotalAttempts() {
+        return totalAttempts;
+    }
+
+    public LocalDateTime getLastAttemptTime() {
+        return lastAttemptTime;
+    }
+
+    public Attempts addAttempt() {
+        this.totalAttempts += 1;
+        this.lastAttemptTime = LocalDateTime.now(clock);
+        return this;
+    }
+}

--- a/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/AbstractSpringTest.java
+++ b/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/AbstractSpringTest.java
@@ -17,7 +17,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 public abstract class AbstractSpringTest {
 
     @Autowired
-    private LoginAttemptService loginAttemptService;
+    protected LoginAttemptService loginAttemptService;
 
     @BeforeEach
     void clearLoginAttempts() {

--- a/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/TestConfiguration.java
+++ b/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/TestConfiguration.java
@@ -6,7 +6,7 @@ import nl._42.max_login_attempts_spring_boot_starter.filter.LoginAttemptFilter;
 import nl._42.restsecure.autoconfigure.HttpSecurityCustomizer;
 import nl._42.restsecure.autoconfigure.RestAuthenticationFilter;
 import nl._42.restsecure.autoconfigure.WebSecurityAutoConfig;
-import nl._42.restsecure.autoconfigure.errorhandling.GenericErrorHandler;
+import nl._42.restsecure.autoconfigure.errorhandling.LoginAuthenticationExceptionHandler;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -36,7 +36,7 @@ public class TestConfiguration extends WebSecurityConfigurerAdapter {
     private LoginAttemptFilter loginAttemptFilter;
 
     @Autowired
-    private GenericErrorHandler genericErrorHandler;
+    private LoginAuthenticationExceptionHandler exceptionHandler;
 
     @Bean
     public Clock clock() {
@@ -60,6 +60,7 @@ public class TestConfiguration extends WebSecurityConfigurerAdapter {
 
     @Bean
     public HttpSecurityCustomizer httpSecurityCustomizer() {
-        return http -> http.csrf().disable().addFilter(new RestAuthenticationFilter(genericErrorHandler, authenticationManager())).addFilterBefore(loginAttemptFilter, RestAuthenticationFilter.class);
+        return http -> http.csrf().disable().addFilter(new RestAuthenticationFilter(exceptionHandler, authenticationManager()))
+                .addFilterBefore(loginAttemptFilter, RestAuthenticationFilter.class);
     }
 }

--- a/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/integration/AuthenticationMaxLoginAttemptsTest.java
+++ b/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/integration/AuthenticationMaxLoginAttemptsTest.java
@@ -6,7 +6,6 @@ import java.time.LocalDateTime;
 
 import nl._42.max_login_attempts_spring_boot_starter.AbstractWebIntegrationTest;
 import nl._42.max_login_attempts_spring_boot_starter.AdjustableClock;
-import nl._42.max_login_attempts_spring_boot_starter.service.LoginAttemptService;
 import nl._42.restsecure.autoconfigure.RestAuthenticationFilter;
 
 import org.junit.jupiter.api.Test;
@@ -19,9 +18,6 @@ class AuthenticationMaxLoginAttemptsTest extends AbstractWebIntegrationTest {
 
     @Autowired
     private AdjustableClock adjustableClock;
-
-    @Autowired
-    private LoginAttemptService loginAttemptService;
 
     @Test
     void loginAndLogoutLog() throws Exception {
@@ -40,57 +36,95 @@ class AuthenticationMaxLoginAttemptsTest extends AbstractWebIntegrationTest {
         pietLoginForm.username = "other-user";
         pietLoginForm.password = "niet-welkom";
 
-
         // The first two attempts are 'free'.
         webClient
-            .perform(MockMvcRequestBuilders.post("/authentication")
-            .content(objectMapper.writeValueAsString(incorrectLoginForm)))
-            .andDo(MockMvcResultHandlers.print())
-            .andExpect(MockMvcResultMatchers.status().isUnauthorized());
+                .perform(MockMvcRequestBuilders.post("/authentication")
+                        .content(objectMapper.writeValueAsString(incorrectLoginForm)))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized());
 
         webClient
-            .perform(MockMvcRequestBuilders.post("/authentication")
-            .content(objectMapper.writeValueAsString(incorrectLoginForm)))
-            .andExpect(MockMvcResultMatchers.status().isUnauthorized());
+                .perform(MockMvcRequestBuilders.post("/authentication")
+                        .content(objectMapper.writeValueAsString(incorrectLoginForm)))
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized());
 
         // At the third incorrect attempt we tried too many times and we are blocked, for the 'Jan' username,
         // but not for the 'Piet' account.
         webClient
-            .perform(MockMvcRequestBuilders.post("/authentication")
-            .content(objectMapper.writeValueAsString(incorrectLoginForm)))
-            .andExpect(MockMvcResultMatchers.status().isForbidden())
-            .andExpect(jsonPath("errorCode").value("TOO_MANY_LOGIN_ATTEMPTS"));
+                .perform(MockMvcRequestBuilders.post("/authentication")
+                        .content(objectMapper.writeValueAsString(incorrectLoginForm)))
+                .andExpect(MockMvcResultMatchers.status().isForbidden())
+                .andExpect(jsonPath("errorCode").value("TOO_MANY_LOGIN_ATTEMPTS"));
 
         webClient
-            .perform(MockMvcRequestBuilders.post("/authentication")
-            .content(objectMapper.writeValueAsString(pietLoginForm)))
-            .andExpect(MockMvcResultMatchers.status().isUnauthorized());
+                .perform(MockMvcRequestBuilders.post("/authentication")
+                        .content(objectMapper.writeValueAsString(pietLoginForm)))
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized());
 
         // We can also still attempt a login with 'Jan' from another IP.
         webClient
-            .perform(MockMvcRequestBuilders.post("/authentication")
-            .content(objectMapper.writeValueAsString(incorrectLoginForm))
-            .with(mockHttpServletRequest -> {
-                mockHttpServletRequest.setRemoteAddr("127.0.0.2");
-                return mockHttpServletRequest;
-            }))
-            .andExpect(MockMvcResultMatchers.status().isUnauthorized());
+                .perform(MockMvcRequestBuilders.post("/authentication")
+                        .content(objectMapper.writeValueAsString(incorrectLoginForm))
+                        .with(mockHttpServletRequest -> {
+                            mockHttpServletRequest.setRemoteAddr("127.0.0.2");
+                            return mockHttpServletRequest;
+                        }))
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized());
 
         // The cooldown time is 1 minute, so we set it just before that minute and try again with the correct credentials, but we are already blocked.
         adjustableClock.setTime(LocalDateTime.of(2020, 1, 1, 0, 0, 59));
 
         webClient
-            .perform(MockMvcRequestBuilders.post("/authentication")
-            .content(objectMapper.writeValueAsString(correctLoginForm)))
-            .andExpect(MockMvcResultMatchers.status().isForbidden())
-            .andExpect(jsonPath("errorCode").value("TOO_MANY_LOGIN_ATTEMPTS"));
+                .perform(MockMvcRequestBuilders.post("/authentication")
+                        .content(objectMapper.writeValueAsString(correctLoginForm)))
+                .andExpect(MockMvcResultMatchers.status().isForbidden())
+                .andExpect(jsonPath("errorCode").value("TOO_MANY_LOGIN_ATTEMPTS"));
 
         // Then we fast-forward time to the point the cache is void and we try again
         adjustableClock.setTime(LocalDateTime.of(2020, 1, 1, 0, 1, 1));
 
         webClient
-            .perform(MockMvcRequestBuilders.post("/authentication")
-            .content(objectMapper.writeValueAsString(correctLoginForm)))
-            .andExpect(MockMvcResultMatchers.status().isOk());
+                .perform(MockMvcRequestBuilders.post("/authentication")
+                        .content(objectMapper.writeValueAsString(correctLoginForm)))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    void resetByUsername() throws Exception {
+        RestAuthenticationFilter.LoginForm incorrectLoginForm = new RestAuthenticationFilter.LoginForm();
+        incorrectLoginForm.username = "admin";
+        incorrectLoginForm.password = "niet-welkom-1337";
+
+        RestAuthenticationFilter.LoginForm correctLoginForm = new RestAuthenticationFilter.LoginForm();
+        correctLoginForm.username = "admin";
+        correctLoginForm.password = "welkom";
+
+        // The first two attempts are 'free'.
+        webClient
+                .perform(MockMvcRequestBuilders.post("/authentication")
+                        .content(objectMapper.writeValueAsString(incorrectLoginForm)))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized());
+
+        webClient
+                .perform(MockMvcRequestBuilders.post("/authentication")
+                        .content(objectMapper.writeValueAsString(incorrectLoginForm)))
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized());
+
+        // At the third incorrect attempt we tried too many times and we are blocked, for the 'Jan' username,
+        // but not for the 'Piet' account.
+        webClient
+                .perform(MockMvcRequestBuilders.post("/authentication")
+                        .content(objectMapper.writeValueAsString(incorrectLoginForm)))
+                .andExpect(MockMvcResultMatchers.status().isForbidden())
+                .andExpect(jsonPath("errorCode").value("TOO_MANY_LOGIN_ATTEMPTS"));
+
+        loginAttemptService.resetByUsername(incorrectLoginForm.username);
+
+        // The first two attempts are 'free'.
+        webClient
+                .perform(MockMvcRequestBuilders.post("/authentication")
+                        .content(objectMapper.writeValueAsString(correctLoginForm)))
+                .andExpect(MockMvcResultMatchers.status().isOk());
     }
 }

--- a/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/integration/ResetSingleUserAfterTimeTest.java
+++ b/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/integration/ResetSingleUserAfterTimeTest.java
@@ -1,0 +1,66 @@
+package nl._42.max_login_attempts_spring_boot_starter.integration;
+
+import java.time.LocalDateTime;
+
+import nl._42.max_login_attempts_spring_boot_starter.AbstractWebIntegrationTest;
+import nl._42.max_login_attempts_spring_boot_starter.AdjustableClock;
+import nl._42.restsecure.autoconfigure.RestAuthenticationFilter;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@ActiveProfiles({ "clear-attempts", "disable-scheduling" })
+class ResetSingleUserAfterTimeTest extends AbstractWebIntegrationTest {
+
+    @Autowired
+    private AdjustableClock adjustableClock;
+
+    @Test
+    void resetByUserAfterTime() throws Exception {
+        RestAuthenticationFilter.LoginForm incorrectLoginForm = new RestAuthenticationFilter.LoginForm();
+        incorrectLoginForm.username = "admin";
+        incorrectLoginForm.password = "niet-welkom-1337";
+
+        RestAuthenticationFilter.LoginForm correctLoginForm = new RestAuthenticationFilter.LoginForm();
+        correctLoginForm.username = "admin";
+        correctLoginForm.password = "welkom";
+
+        RestAuthenticationFilter.LoginForm pietLoginForm = new RestAuthenticationFilter.LoginForm();
+        pietLoginForm.username = "other-user";
+        pietLoginForm.password = "niet-welkom";
+
+        // The first two attempts are 'free'.
+        webClient
+                .perform(MockMvcRequestBuilders.post("/authentication")
+                        .content(objectMapper.writeValueAsString(incorrectLoginForm)))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized());
+
+        webClient
+                .perform(MockMvcRequestBuilders.post("/authentication")
+                        .content(objectMapper.writeValueAsString(incorrectLoginForm)))
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized());
+
+        adjustableClock.setTime(LocalDateTime.now().plusMinutes(35));
+
+        webClient
+                .perform(MockMvcRequestBuilders.post("/authentication")
+                        .content(objectMapper.writeValueAsString(incorrectLoginForm)))
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized());
+
+        webClient
+                .perform(MockMvcRequestBuilders.post("/authentication")
+                        .content(objectMapper.writeValueAsString(incorrectLoginForm)))
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized());
+
+        webClient
+                .perform(MockMvcRequestBuilders.post("/authentication")
+                        .content(objectMapper.writeValueAsString(correctLoginForm)))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+
+    }
+}

--- a/src/test/resources/application-clear-attempts.yml
+++ b/src/test/resources/application-clear-attempts.yml
@@ -1,0 +1,3 @@
+max-login-attempts-starter:
+  clear-attempts-seconds: 1800
+  max-attempts: 3


### PR DESCRIPTION
Added the property clear-attempts-ms to specify the duration in ms of when
the attempts of a username should be reset.