### PR TITLE
Simplified the LoginAttemptServiceImplementation

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,18 +2,18 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
 name: Java CI with Maven
-
 on:
   push:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'java' ]
     steps:
       - name: Repository checkout
         uses: actions/checkout@v2
@@ -33,3 +33,11 @@ jobs:
         run: mvn clean verify
       - name: Code coverage with Codecov
         uses: codecov/codecov-action@v1
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
+      - name: Compile project for CodeQL
+        run: mvn clean compile
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <commons-io.version>2.8.0</commons-io.version>
 
-        <spring-boot.version>2.4.1</spring-boot.version>
+        <spring-boot.version>2.4.2</spring-boot.version>
     </properties>
 
     <dependencies>
@@ -79,6 +79,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>
 
@@ -164,6 +169,19 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.4.2</version>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-configuration-processor</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.6</version>
@@ -185,7 +203,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>6.0.4</version>
+                <version>6.1.0</version>
                 <configuration>
                     <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
                     <skipProvidedScope>true</skipProvidedScope>

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/LoginAttemptConfiguration.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/LoginAttemptConfiguration.java
@@ -10,12 +10,32 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 @Component
-@ConfigurationProperties(prefix = "max-login-attempts-starter")
+@ConfigurationProperties("max-login-attempts-starter")
 public class LoginAttemptConfiguration {
 
+    /**
+     * Enable or disable the max-login-attempts library.
+     */
     private boolean enabled = true;
+
+    /**
+     * Sets the total attempts a user can incorrectly login.
+     */
     private int maxAttempts = 5;
-    private int cooldown = 60000;
+
+    /**
+     * Sets the cooldown time of when a user is blocked.
+     */
+    private int cooldownInMs = 60000;
+
+    /**
+     * Cron for clearing all users from the attempts cache.
+     */
+    private String clearAllAttemptsCron = "0 0 0 * * *";
+
+    /**
+     * Sets the cooldown time of when a user is blocked.
+     */
     private List<AuthenticationEndpoint> authenticationEndpoints = singletonList(
             AuthenticationEndpoint.create("/authentication", POST)
     );
@@ -36,12 +56,20 @@ public class LoginAttemptConfiguration {
         this.maxAttempts = maxAttempts;
     }
 
-    public int getCooldown() {
-        return cooldown;
+    public int getCooldownInMs() {
+        return cooldownInMs;
     }
 
-    public void setCooldown(int cooldown) {
-        this.cooldown = cooldown;
+    public void setCooldownInMs(int cooldownInMs) {
+        this.cooldownInMs = cooldownInMs;
+    }
+
+    public String getClearAllAttemptsCron() {
+        return clearAllAttemptsCron;
+    }
+
+    public void setClearAllAttemptsCron(String clearAllAttemptsCron) {
+        this.clearAllAttemptsCron = clearAllAttemptsCron;
     }
 
     public List<AuthenticationEndpoint> getAuthenticationEndpoints() {

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/LoginAttemptsAutoConfig.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/LoginAttemptsAutoConfig.java
@@ -23,7 +23,7 @@ public class LoginAttemptsAutoConfig {
 
     @Bean
     @ConditionalOnMissingBean(TooManyLoginAttemptsErrorHandler.class)
-    public TooManyLoginAttemptsErrorHandler TooManyLoginAttemptsErrorHandler() {
+    public TooManyLoginAttemptsErrorHandler tooManyLoginAttemptsErrorHandler() {
         return new DefaultTooManyLoginAttemptsErrorHandler();
     }
 }

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/service/AttemptsMonitor.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/service/AttemptsMonitor.java
@@ -1,0 +1,47 @@
+package nl._42.max_login_attempts_spring_boot_starter.service;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+public class AttemptsMonitor {
+
+    private int attempts;
+    private LocalDateTime unblockTime;
+
+    public AttemptsMonitor() {
+        setDefaultValues();
+    }
+
+    public int getAttempts() {
+        return this.attempts;
+    }
+
+    public LocalDateTime getUnblockTime() {
+        return unblockTime;
+    }
+
+    public void addAttempt() {
+        this.attempts += 1;
+    }
+
+    public void block(LocalDateTime unblockTime) {
+        this.unblockTime = unblockTime;
+    }
+
+    public void unblock() {
+        this.unblockTime = null;
+    }
+
+    public void reset() {
+        setDefaultValues();
+    }
+
+    public boolean isBlocked(Clock clock) {
+        return unblockTime != null && LocalDateTime.now(clock).isBefore(unblockTime);
+    }
+
+    private void setDefaultValues() {
+        this.attempts = 0;
+        this.unblockTime = null;
+    }
+}

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/service/LoginAttemptServiceImplementation.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/service/LoginAttemptServiceImplementation.java
@@ -20,22 +20,17 @@ import org.springframework.stereotype.Service;
 @ConditionalOnProperty(value = "max-login-attempts-starter.enabled", matchIfMissing = true)
 public class LoginAttemptServiceImplementation implements LoginAttemptService {
 
-    public static final String DEFAULT_CLEAR_ALL_ATTEMPTS_CRON = "'0 0 0 * * *'";
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(LoginAttemptServiceImplementation.class);
-
+    private final Logger log = LoggerFactory.getLogger(LoginAttemptServiceImplementation.class);
     private final LoginAttemptConfiguration loginAttemptConfiguration;
     private final Clock clock;
 
-    private final ConcurrentHashMap<UsernameIPAddress, Integer> attemptsCache;
-    private final ConcurrentHashMap<UsernameIPAddress, LocalDateTime> blockedUsernameIPAddresses;
+    private final ConcurrentHashMap<UsernameIPAddress, AttemptsMonitor> userCache;
 
     public LoginAttemptServiceImplementation(LoginAttemptConfiguration loginAttemptConfiguration, Clock clock) {
         this.loginAttemptConfiguration = loginAttemptConfiguration;
         this.clock = clock;
 
-        this.attemptsCache = new ConcurrentHashMap<>();
-        this.blockedUsernameIPAddresses = new ConcurrentHashMap<>();
+        this.userCache = new ConcurrentHashMap<>();
     }
 
     /**
@@ -54,41 +49,40 @@ public class LoginAttemptServiceImplementation implements LoginAttemptService {
      */
     @Override
     public synchronized boolean loginFailed(String username, String remoteAddress) {
-        LOGGER.debug("User {} on remote address {} used incorrect login credentials. Added a counter to the login attempts.", username, remoteAddress);
+        log.debug("User {} on remote address {} used incorrect login credentials. Added a counter to the login attempts.", username, remoteAddress);
 
         // If the remoteAddress is already blocked we don't need to do anything and return.
         if (isBlocked(username, remoteAddress)) {
-            LOGGER.debug("User {} on remote address {} was already blocked, no additional failure is added.", username, remoteAddress);
+            log.debug("User {} on remote address {} was already blocked, no additional failure is added.", username, remoteAddress);
             return true;
         }
 
         UsernameIPAddress usernameIPAddress = new UsernameIPAddress(username, remoteAddress);
 
-        int attempts = attemptsCache.getOrDefault(usernameIPAddress, 0);
-        attemptsCache.put(usernameIPAddress, attempts + 1);
+        AttemptsMonitor attemptsMonitor = getAttemptsMonitor(usernameIPAddress);
+        attemptsMonitor.addAttempt();
+        userCache.putIfAbsent(usernameIPAddress, attemptsMonitor);
 
         /*
          * If the remoteAddress is now blocked we mark it for removal
          * but we clear the attempts so the counter starts to re-run
          * when the unblock deadline has passed.
          */
-        if (hasReachedLoginAttemptLimit(username, remoteAddress)) {
+        if (hasReachedLoginAttemptLimit(attemptsMonitor)) {
             int attemptLimit = loginAttemptConfiguration.getMaxAttempts();
-            LocalDateTime unblockTime = LocalDateTime.now(clock).plusSeconds(loginAttemptConfiguration.getCooldown() / 1000);
+            LocalDateTime unblockTime = LocalDateTime.now(clock).plusSeconds(loginAttemptConfiguration.getCooldownInMs() / 1000);
 
-            LOGGER.warn("User {} on remote address {} has reached the login attempt limit of {} and is now blocked until {}.",  username, remoteAddress, attemptLimit, unblockTime);
-            clearAttempts(usernameIPAddress);
-            blockedUsernameIPAddresses.put(usernameIPAddress, unblockTime);
+            log.warn("User {} on remote address {} has reached the login attempt limit of {} and is now blocked until {}.",  username, remoteAddress, attemptLimit, unblockTime);
+            attemptsMonitor.reset();
+            attemptsMonitor.block(unblockTime);
             return true;
         }
 
         return false;
     }
 
-    private boolean hasReachedLoginAttemptLimit(String username, String remoteAddress) {
-        UsernameIPAddress usernameIPAddress = new UsernameIPAddress(username, remoteAddress);
-        int attempts = attemptsCache.getOrDefault(usernameIPAddress, 0);
-        return attempts >= loginAttemptConfiguration.getMaxAttempts();
+    private boolean hasReachedLoginAttemptLimit(AttemptsMonitor attemptsMonitor) {
+        return attemptsMonitor.getAttempts() >= loginAttemptConfiguration.getMaxAttempts();
     }
 
     /**
@@ -98,17 +92,13 @@ public class LoginAttemptServiceImplementation implements LoginAttemptService {
      */
     @Override
     public void loginSucceeded(String username, String remoteAddress) {
-        LOGGER.debug("User {} on remote address {} succeeded to login.", username, remoteAddress);
+        log.debug("User {} on remote address {} succeeded to login.", username, remoteAddress);
         UsernameIPAddress usernameIPAddress = new UsernameIPAddress(username, remoteAddress);
-        clearAttempts(usernameIPAddress);
+        getAttemptsMonitor(usernameIPAddress).reset();
     }
 
-    private void clearAttempts(UsernameIPAddress usernameIPAddress) {
-        attemptsCache.remove(usernameIPAddress);
-    }
-
-    private void clearBlocked(UsernameIPAddress usernameIPAddress) {
-        blockedUsernameIPAddresses.remove(usernameIPAddress);
+    private AttemptsMonitor getAttemptsMonitor(UsernameIPAddress usernameIPAddress) {
+        return userCache.getOrDefault(usernameIPAddress, new AttemptsMonitor());
     }
 
     /**
@@ -120,40 +110,28 @@ public class LoginAttemptServiceImplementation implements LoginAttemptService {
     public synchronized boolean isBlocked(String username, String remoteAddress) {
         UsernameIPAddress usernameIPAddress = new UsernameIPAddress(username, remoteAddress);
 
-        /*
-         * If the username/ip-address combination is not currently in the
-         * blockedUsernameIPAddresses map we are sure it is not blocked.
-         */
-        if (!blockedUsernameIPAddresses.containsKey(usernameIPAddress)) {
-            return false;
-        }
-
         // Otherwise we retrieve the unblockTime and check if it has passed.
         // If it has passed we do a little cleanup and remove the record.
-        LocalDateTime unblockTime = blockedUsernameIPAddresses.get(usernameIPAddress);
-        if (LocalDateTime.now(clock).isBefore(unblockTime)) {
-            LOGGER.debug("User {} on remote address {} cannot log in because he is blocked until {}", username, remoteAddress, unblockTime);
+        AttemptsMonitor attemptsMonitor = getAttemptsMonitor(usernameIPAddress);
+        LocalDateTime unblockTime = attemptsMonitor.getUnblockTime();
+        if (attemptsMonitor.isBlocked(clock)) {
+            log.debug("User {} on remote address {} cannot log in because he is blocked until {}", username, remoteAddress, unblockTime);
             return true;
         } else {
-            LOGGER.debug("User {} on remote address {} may login again because the unblock time of {} has passed.", unblockTime, remoteAddress, unblockTime);
-            blockedUsernameIPAddresses.remove(usernameIPAddress);
+            log.debug("User {} on remote address {} may login again because the unblock time of {} has passed.", unblockTime, remoteAddress, unblockTime);
+            attemptsMonitor.unblock();
             return false;
         }
     }
 
     @Override
     public synchronized void resetByUsername(String username) {
-        LOGGER.info("Clearing login attempt records of user {}.", username);
-        Optional<Map.Entry<UsernameIPAddress, Integer>> entryAttempt = attemptsCache.entrySet().stream()
+        log.info("Clearing login attempt records of user {}.", username);
+        Optional<Map.Entry<UsernameIPAddress, AttemptsMonitor>> entryAttempt = userCache.entrySet().stream()
                 .filter(k -> k.getKey().getUsername().equals(username))
                 .findFirst();
 
-        Optional<Map.Entry<UsernameIPAddress, LocalDateTime>> entryBlocked = blockedUsernameIPAddresses.entrySet().stream()
-                .filter(k -> k.getKey().getUsername().equals(username))
-                .findFirst();
-
-        entryAttempt.ifPresent(entry -> clearAttempts(entry.getKey()));
-        entryBlocked.ifPresent(entry -> clearBlocked(entry.getKey()));
+        entryAttempt.ifPresent(entry -> getAttemptsMonitor(entry.getKey()).reset());
     }
 
     /**
@@ -161,10 +139,9 @@ public class LoginAttemptServiceImplementation implements LoginAttemptService {
      * Can be executed manually and also be scheduled to reset automatically.
      */
     @Override
-    @Scheduled(cron = "${max-login-attempts-starter.clear-all-attempts-cron:#{" + DEFAULT_CLEAR_ALL_ATTEMPTS_CRON + "}}")
+    @Scheduled(cron = "#{@loginAttemptConfiguration.clearAllAttemptsCron}")
     public synchronized void reset() {
-        LOGGER.info("Clearing all login attempt records.");
-        attemptsCache.clear();
-        blockedUsernameIPAddresses.clear();
+        log.info("Clearing all login attempt records.");
+        userCache.clear();
     }
 }

--- a/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/integration/AuthenticationMaxLoginAttemptsTest.java
+++ b/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/integration/AuthenticationMaxLoginAttemptsTest.java
@@ -20,9 +20,6 @@ class AuthenticationMaxLoginAttemptsTest extends AbstractWebIntegrationTest {
     @Autowired
     private AdjustableClock adjustableClock;
 
-    @Autowired
-    private LoginAttemptService loginAttemptService;
-
     @Test
     void loginAndLogoutLog() throws Exception {
         // The current time is January 1st, 2020, 00:00:00

--- a/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/integration/LoginAttemptConfigurationTest.java
+++ b/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/integration/LoginAttemptConfigurationTest.java
@@ -1,0 +1,22 @@
+package nl._42.max_login_attempts_spring_boot_starter.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import nl._42.max_login_attempts_spring_boot_starter.AbstractWebIntegrationTest;
+import nl._42.max_login_attempts_spring_boot_starter.LoginAttemptConfiguration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class LoginAttemptConfigurationTest extends AbstractWebIntegrationTest {
+
+    @Autowired
+    private LoginAttemptConfiguration loginAttemptConfiguration;
+
+    @Test
+    void applicationPropertiesCorrectyMapped() {
+        assertEquals(3, loginAttemptConfiguration.getMaxAttempts());
+        assertEquals(60001, loginAttemptConfiguration.getCooldownInMs());
+        assertEquals("0 */1 * * *", loginAttemptConfiguration.getClearAllAttemptsCron());
+    }
+}

--- a/src/test/resources/application-unit-test.yml
+++ b/src/test/resources/application-unit-test.yml
@@ -1,2 +1,4 @@
 max-login-attempts-starter:
   max-attempts: 3
+  cooldown-in-ms: 60001
+  clear-all-attempts-cron: '0 */1 * * *'


### PR DESCRIPTION
- Added the Attempt class for holding the attempts and unblock data.
- Moved the default clear all cron to the LoginAttemptConfiguration class,
so that the property can be autocompleted in an IDEA.
- Added the spring-boot-configuration-processor library so that the
configuration properties can be autocompleted in supported IDEA's of the
library.
- In LoginAttemptServiceImplementation merged the attemptsCache and
blockedUsernameIPAddresses to the userCache for storing the new Attempt
class.
- Property cooldown-in-ms was incorrecly documented, because the property
was cooldown. Fixed this by changing the property in
LoginAttemptConfiguration from cooldown to cooldownInMs so the value is
correctly mapped