### PR TITLE
fix: lockout entries surviving a reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.0.0] 2026-07-31
+- **Breaking**: usernames are matched case-insensitively (and ignoring surrounding whitespace) by default. Failed attempts, block checks and resets now refer to the same record regardless of how the username was typed in the login form. Applications with case-sensitive usernames (where `Admin` and `admin` are different users) must set the new property `max-login-attempts-starter.case-sensitive-usernames: true` to keep tracking those users separately.
+- `resetByUsername` now clears the login attempt records of a user for every remote address, instead of only the first matching entry.
+- Successful logins now actually clear the failed attempt counter. The success listener used the toString of the authenticated principal (a `UserDetails` object) instead of its username, so counters kept accumulating until the scheduled cache clear.
+
 ## [3.0.0] 2025-12-03
 - Upgraded to Java 21, Spring Boot 4
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,20 @@ max-login-attempts-starter:
   cooldown-in-ms: 90000 # (1,5 minute)
 ``` 
 
+## Case-sensitive usernames
+
+Usernames are normalized (trimmed and lowercased) before they are used in the lockout
+administration, so failed attempts, block checks and resets refer to the same record however
+the username was typed in the login form. If usernames are case-sensitive in your application
+(`Admin` and `admin` can be different users), enable case-sensitive matching:
+
+```yaml
+max-login-attempts-starter:
+  case-sensitive-usernames: true
+```
+
+Usernames are still trimmed of surrounding whitespace when this setting is enabled.
+
 ## Overriding the default CRON that resets the counters
 
 Because it is probably not desirable that failed login attempts are counted "over multiple days",

--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -1,3 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+        CVE-2026-47838 (SubjectDnX509PrincipalExtractor username spoofing via crafted client
+        certificate) is a false positive on spring-security-web 7.1.0 caused by an over-broad
+        CPE match. Per https://spring.io/security/cve-2026-47838/ the CVE affects 5.7.x-6.5.x
+        (fixed in 6.5.11); the 7.x line received the equivalent fix under CVE-2026-22747 in
+        7.0.5, and in 7.1.0 SubjectDnX509PrincipalExtractor is deprecated and
+        X509AuthenticationFilter defaults to the fixed SubjectX500PrincipalExtractor.
+        Additionally, this starter does not use X.509 pre-authentication at all (form/JSON
+        login only), so none of the exploitation preconditions apply.
+        The packageUrl below is scoped to the 7.x line on purpose: should a genuinely
+        vulnerable 6.x spring-security-web ever be resolved, this suppression stops applying
+        and dependency-check will flag it again.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring-security-web@7\..*$</packageUrl>
+        <cve>CVE-2026-47838</cve>
+    </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,10 @@
             <name>Bas de Vos</name>
             <email>bas.de.vos@42.nl</email>
         </developer>
+        <developer>
+            <name>Arjan Vlek</name>
+            <email>arjan.vlek@42.nl</email>
+        </developer>
     </developers>
 
     <scm>
@@ -51,12 +55,19 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.release>21</maven.compiler.release>
 
-        <spring-boot.version>4.0.0</spring-boot.version>
-        <rest-secure-starter.version>15.0.0</rest-secure-starter.version>
-        <commons-io.version>2.21.0</commons-io.version>
+        <spring-boot.version>4.1.0</spring-boot.version>
+        <rest-secure-starter.version>16.1.0</rest-secure-starter.version>
+        <commons-io.version>2.22.0</commons-io.version>
 
-        <dependency-check-maven-plugin.version>12.1.9</dependency-check-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
+        <!-- CVE overrides of versions managed by spring-boot-dependencies.
+             Remove once Spring Boot manages these versions (or higher). -->
+        <tomcat.version>11.0.24</tomcat.version><!-- CVE-2026-53434 et al., fixed in 11.0.24 -->
+        <logback.version>1.5.38</logback.version><!-- CVE-2026-13006, fixed in 1.5.37 -->
+        <log4j2.version>2.25.5</log4j2.version><!-- CVE-2026-49844, fixed in 2.25.5 -->
+        <jackson.version>3.1.5</jackson.version><!-- CVE-2026-59889, fixed in 3.1.5 -->
+
+        <dependency-check-maven-plugin.version>12.2.2</dependency-check-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
         <central-publishing-plugin.version>0.9.0</central-publishing-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
@@ -124,6 +135,55 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- CVE overrides: these entries must precede the spring-boot-dependencies import,
+                 because property overrides do not work when importing the BOM (as opposed to
+                 inheriting from spring-boot-starter-parent). -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${log4j2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-to-slf4j</artifactId>
+                <version>${log4j2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>nl.42</groupId>
     <artifactId>max-login-attempts-spring-boot-starter</artifactId>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Max Login Attempts Spring Boot Starter</name>
     <description>Allows you to limit the number of login attempts</description>

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/LoginAttemptConfiguration.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/LoginAttemptConfiguration.java
@@ -34,6 +34,12 @@ public class LoginAttemptConfiguration {
     private String clearAllAttemptsCron = "0 0 0 * * *";
 
     /**
+     * Match usernames case-sensitively in the lockout administration. Enable this when usernames
+     * are case-sensitive in your application, i.e. 'Admin' and 'admin' can be different users.
+     */
+    private boolean caseSensitiveUsernames = false;
+
+    /**
      * Sets the cooldown time of when a user is blocked.
      */
     private List<AuthenticationEndpoint> authenticationEndpoints = singletonList(
@@ -70,6 +76,14 @@ public class LoginAttemptConfiguration {
 
     public void setClearAllAttemptsCron(String clearAllAttemptsCron) {
         this.clearAllAttemptsCron = clearAllAttemptsCron;
+    }
+
+    public boolean isCaseSensitiveUsernames() {
+        return caseSensitiveUsernames;
+    }
+
+    public void setCaseSensitiveUsernames(boolean caseSensitiveUsernames) {
+        this.caseSensitiveUsernames = caseSensitiveUsernames;
     }
 
     public List<AuthenticationEndpoint> getAuthenticationEndpoints() {

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/listener/AuthenticationSuccessListener.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/listener/AuthenticationSuccessListener.java
@@ -7,6 +7,7 @@ import nl._42.max_login_attempts_spring_boot_starter.service.LoginAttemptService
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationListener;
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -26,9 +27,20 @@ public class AuthenticationSuccessListener implements ApplicationListener<Authen
     public void onApplicationEvent(AuthenticationSuccessEvent event) {
         RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
         if (requestAttributes instanceof ServletRequestAttributes attributes) {
-            String username = String.valueOf(event.getAuthentication().getPrincipal());
+            String username = extractUsername(event.getAuthentication().getPrincipal());
             HttpServletRequest request = attributes.getRequest();
             loginAttemptService.loginSucceeded(username, request.getRemoteAddr());
         }
+    }
+
+    /**
+     * On a successful authentication the principal is no longer the username typed in the login
+     * form but the {@link UserDetails} of the authenticated user, whose toString is not a username.
+     */
+    private String extractUsername(Object principal) {
+        if (principal instanceof UserDetails userDetails) {
+            return userDetails.getUsername();
+        }
+        return String.valueOf(principal);
     }
 }

--- a/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/service/LoginAttemptServiceImplementation.java
+++ b/src/main/java/nl/_42/max_login_attempts_spring_boot_starter/service/LoginAttemptServiceImplementation.java
@@ -2,8 +2,7 @@ package nl._42.max_login_attempts_spring_boot_starter.service;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
-import java.util.Map;
-import java.util.Optional;
+import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 
 import nl._42.max_login_attempts_spring_boot_starter.LoginAttemptConfiguration;
@@ -57,7 +56,7 @@ public class LoginAttemptServiceImplementation implements LoginAttemptService {
             return true;
         }
 
-        UsernameIPAddress usernameIPAddress = new UsernameIPAddress(username, remoteAddress);
+        UsernameIPAddress usernameIPAddress = key(username, remoteAddress);
 
         AttemptsMonitor attemptsMonitor = getAttemptsMonitor(usernameIPAddress);
         attemptsMonitor.addAttempt();
@@ -91,10 +90,9 @@ public class LoginAttemptServiceImplementation implements LoginAttemptService {
      * @param remoteAddress remote internet address
      */
     @Override
-    public void loginSucceeded(String username, String remoteAddress) {
+    public synchronized void loginSucceeded(String username, String remoteAddress) {
         log.debug("User {} on remote address {} succeeded to login.", username, remoteAddress);
-        UsernameIPAddress usernameIPAddress = new UsernameIPAddress(username, remoteAddress);
-        getAttemptsMonitor(usernameIPAddress).reset();
+        userCache.remove(key(username, remoteAddress));
     }
 
     private AttemptsMonitor getAttemptsMonitor(UsernameIPAddress usernameIPAddress) {
@@ -108,7 +106,7 @@ public class LoginAttemptServiceImplementation implements LoginAttemptService {
      */
     @Override
     public synchronized boolean isBlocked(String username, String remoteAddress) {
-        UsernameIPAddress usernameIPAddress = new UsernameIPAddress(username, remoteAddress);
+        UsernameIPAddress usernameIPAddress = key(username, remoteAddress);
 
         // Otherwise we retrieve the unblockTime and check if it has passed.
         // If it has passed we do a little cleanup and remove the record.
@@ -124,14 +122,28 @@ public class LoginAttemptServiceImplementation implements LoginAttemptService {
         }
     }
 
+    /**
+     * Clears the login attempt records of the given username for every remote address.
+     * Unless case-sensitive usernames are enabled, the username is matched case-insensitively,
+     * so the records are also cleared when the failed attempts were typed with a different casing.
+     */
     @Override
     public synchronized void resetByUsername(String username) {
         log.info("Clearing login attempt records of user {}.", username);
-        Optional<Map.Entry<UsernameIPAddress, AttemptsMonitor>> entryAttempt = userCache.entrySet().stream()
-                .filter(k -> k.getKey().getUsername().equals(username))
-                .findFirst();
+        String normalized = normalize(username);
+        userCache.keySet().removeIf(key -> key.getUsername().equals(normalized));
+    }
 
-        entryAttempt.ifPresent(entry -> getAttemptsMonitor(entry.getKey()).reset());
+    private UsernameIPAddress key(String username, String remoteAddress) {
+        return new UsernameIPAddress(normalize(username), remoteAddress);
+    }
+
+    private String normalize(String username) {
+        if (username == null) {
+            return "";
+        }
+        String trimmed = username.trim();
+        return loginAttemptConfiguration.isCaseSensitiveUsernames() ? trimmed : trimmed.toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/integration/CaseSensitiveLoginAttemptTest.java
+++ b/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/integration/CaseSensitiveLoginAttemptTest.java
@@ -1,0 +1,44 @@
+package nl._42.max_login_attempts_spring_boot_starter.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import nl._42.max_login_attempts_spring_boot_starter.AbstractSpringTest;
+import nl._42.max_login_attempts_spring_boot_starter.service.LoginAttemptService;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource(properties = "max-login-attempts-starter.case-sensitive-usernames=true")
+class CaseSensitiveLoginAttemptTest extends AbstractSpringTest {
+
+    private static final String REMOTE_ADDRESS = "127.0.0.1";
+
+    @Autowired
+    private LoginAttemptService loginAttemptService;
+
+    @Test
+    void differentCasings_shouldBeTrackedAsDifferentUsers() {
+        block("Admin");
+
+        assertThat(loginAttemptService.isBlocked("Admin", REMOTE_ADDRESS)).isTrue();
+        assertThat(loginAttemptService.isBlocked("admin", REMOTE_ADDRESS)).isFalse();
+    }
+
+    @Test
+    void resetByUsername_shouldOnlyClearTheExactCasing() {
+        block("Admin");
+
+        loginAttemptService.resetByUsername("admin");
+        assertThat(loginAttemptService.isBlocked("Admin", REMOTE_ADDRESS)).isTrue();
+
+        loginAttemptService.resetByUsername("Admin");
+        assertThat(loginAttemptService.isBlocked("Admin", REMOTE_ADDRESS)).isFalse();
+    }
+
+    private void block(String username) {
+        for (int attempt = 0; attempt < 3; attempt++) {
+            loginAttemptService.loginFailed(username, REMOTE_ADDRESS);
+        }
+    }
+}

--- a/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/integration/LoginAttemptConfigurationTest.java
+++ b/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/integration/LoginAttemptConfigurationTest.java
@@ -1,6 +1,7 @@
 package nl._42.max_login_attempts_spring_boot_starter.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import nl._42.max_login_attempts_spring_boot_starter.AbstractWebIntegrationTest;
 import nl._42.max_login_attempts_spring_boot_starter.LoginAttemptConfiguration;
@@ -18,5 +19,6 @@ class LoginAttemptConfigurationTest extends AbstractWebIntegrationTest {
         assertEquals(3, loginAttemptConfiguration.getMaxAttempts());
         assertEquals(60001, loginAttemptConfiguration.getCooldownInMs());
         assertEquals("0 */1 * * *", loginAttemptConfiguration.getClearAllAttemptsCron());
+        assertFalse(loginAttemptConfiguration.isCaseSensitiveUsernames());
     }
 }

--- a/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/integration/LoginAttemptResetTest.java
+++ b/src/test/java/nl/_42/max_login_attempts_spring_boot_starter/integration/LoginAttemptResetTest.java
@@ -1,0 +1,85 @@
+package nl._42.max_login_attempts_spring_boot_starter.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import nl._42.max_login_attempts_spring_boot_starter.AbstractWebIntegrationTest;
+import nl._42.max_login_attempts_spring_boot_starter.service.LoginAttemptService;
+import nl._42.restsecure.autoconfigure.form.LoginForm;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+class LoginAttemptResetTest extends AbstractWebIntegrationTest {
+
+    private static final String DEFAULT_REMOTE_ADDRESS = "127.0.0.1";
+    private static final String OTHER_REMOTE_ADDRESS = "127.0.0.2";
+
+    @Autowired
+    private LoginAttemptService loginAttemptService;
+
+    @Test
+    void resetByUsername_shouldClearAllEntriesOfUser_regardlessOfCasingAndRemoteAddress() throws Exception {
+        // Block the user on two remote addresses, typing the username with different casings.
+        blockUser("ADMIN", DEFAULT_REMOTE_ADDRESS);
+        blockUser("Admin", OTHER_REMOTE_ADDRESS);
+
+        // The block also holds for the lowercase username, even with the correct password.
+        login("admin", "welkom", DEFAULT_REMOTE_ADDRESS)
+            .andExpect(MockMvcResultMatchers.status().isForbidden())
+            .andExpect(jsonPath("errorCode").value("TOO_MANY_LOGIN_ATTEMPTS"));
+
+        loginAttemptService.resetByUsername(" Admin ");
+
+        // The reset clears the records of every remote address, whatever the casing was.
+        login("admin", "welkom", DEFAULT_REMOTE_ADDRESS)
+            .andExpect(MockMvcResultMatchers.status().isOk());
+        assertThat(loginAttemptService.isBlocked("admin", OTHER_REMOTE_ADDRESS)).isFalse();
+    }
+
+    @Test
+    void successfulLogin_shouldClearFailedAttempts() throws Exception {
+        // Two failed attempts: one below the limit of three.
+        login("admin", "niet-welkom", DEFAULT_REMOTE_ADDRESS)
+            .andExpect(MockMvcResultMatchers.status().isUnauthorized());
+        login("admin", "niet-welkom", DEFAULT_REMOTE_ADDRESS)
+            .andExpect(MockMvcResultMatchers.status().isUnauthorized());
+
+        login("admin", "welkom", DEFAULT_REMOTE_ADDRESS)
+            .andExpect(MockMvcResultMatchers.status().isOk());
+
+        // The successful login cleared the counter, so two more failed attempts do not add up
+        // to the earlier two and the user is not blocked.
+        login("admin", "niet-welkom", DEFAULT_REMOTE_ADDRESS)
+            .andExpect(MockMvcResultMatchers.status().isUnauthorized());
+        login("admin", "niet-welkom", DEFAULT_REMOTE_ADDRESS)
+            .andExpect(MockMvcResultMatchers.status().isUnauthorized());
+
+        login("admin", "welkom", DEFAULT_REMOTE_ADDRESS)
+            .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    private void blockUser(String username, String remoteAddress) throws Exception {
+        for (int attempt = 0; attempt < 3; attempt++) {
+            login(username, "niet-welkom", remoteAddress);
+        }
+        assertThat(loginAttemptService.isBlocked(username, remoteAddress)).isTrue();
+    }
+
+    private ResultActions login(String username, String password, String remoteAddress) throws Exception {
+        LoginForm loginForm = new LoginForm();
+        loginForm.username = username;
+        loginForm.password = password;
+
+        return webClient
+            .perform(MockMvcRequestBuilders.post("/authentication")
+                .content(objectMapper.writeValueAsString(loginForm))
+                .with(mockHttpServletRequest -> {
+                    mockHttpServletRequest.setRemoteAddr(remoteAddress);
+                    return mockHttpServletRequest;
+                }));
+    }
+}


### PR DESCRIPTION
- BREAKING CHANGE: usernames are normalized (trimmed, lowercased) by default, so failed attempts, block checks and resets match regardless of how the username was typed in the login form. Applications with case-sensitive usernames can restore per-casing tracking with the new property `max-login-attempts-starter.case-sensitive-usernames`.
- `resetByUsername()` now clears the records of a user for every remote address instead of only the first matching entry.
- Successful logins now actually clear the failed attempt counter: the success listener used the `toString()` of the authenticated principal instead of its username.

Version bumped to 4.0.0 because the default matching semantics changed.